### PR TITLE
fix(amplify-appsync-simulator): velocity template handles unknow type…

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/index.test.ts
@@ -1,0 +1,68 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { AmplifyAppSyncSimulator } from '../..';
+import { AmplifyAppSyncSimulatorAuthenticationType } from '../../type-definition';
+import { VelocityTemplate } from '../../velocity';
+import { mockInfo } from './util/general-utils.test';
+
+describe('VelocityTemplate', () => {
+  let content;
+  let simulator;
+  beforeAll(() => {
+    content = `"$ctx.error.message, $ctx.error.type"`;
+    simulator = new AmplifyAppSyncSimulator();
+  });
+
+  describe('#render', () => {
+    it('should handle unknow errors', () => {
+      const template = new VelocityTemplate(
+        {
+          path: 'INLINE_TEMPLATE',
+          content,
+        },
+        simulator,
+      );
+      const info = mockInfo;
+      const result = template.render(
+        {
+          error: new Error('some unexpected error'),
+          arguments: {},
+          source: {},
+        },
+        {
+          headers: { Key: 'value' },
+          requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.API_KEY,
+        },
+        info,
+      );
+      expect(result.errors).toEqual([]);
+      expect(result.result).toEqual('some unexpected error, UnknowErrorType');
+    });
+  });
+
+  describe('#render', () => {
+    it('should handle with a not error in error', () => {
+      const template = new VelocityTemplate(
+        {
+          path: 'INLINE_TEMPLATE',
+          content,
+        },
+        simulator,
+      );
+      const info = mockInfo;
+      const result = template.render(
+        {
+          error: 'my string as error',
+          arguments: {},
+          source: {},
+        },
+        {
+          headers: { Key: 'value' },
+          requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.API_KEY,
+        },
+        info,
+      );
+      expect(result.errors).toEqual([]);
+      expect(result.result).toEqual('Error: my string as error, UnknowErrorType');
+    });
+  });
+});

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/general-utils.test.ts
@@ -41,7 +41,7 @@ const stubInfo = {
     },
   },
 } as unknown;
-const mockInfo = stubInfo as GraphQLResolveInfo;
+export const mockInfo = stubInfo as GraphQLResolveInfo;
 const stubJavaMap: JavaMap = new JavaMap({ field1: 'field1Value', field2: 'field2Value', field3: 'field3Value' }, x => x);
 var util;
 

--- a/packages/amplify-appsync-simulator/src/velocity/index.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/index.ts
@@ -114,7 +114,13 @@ export class VelocityTemplate {
       result: convertToJavaTypes(result),
       // surfacing the errorType to ensure the type is included in $ctx.error
       // Mapping Template Errors: https://docs.aws.amazon.com/appsync/latest/devguide/troubleshooting-and-common-mistakes.html#mapping-template-errors
-      error: error ? { ...error, type: error.extensions.errorType } : error,
+      error: error
+        ? {
+            ...error,
+            type: error.extensions?.errorType || 'UnknowErrorType',
+            message: error.message || `Error: ${error}`,
+          }
+        : error,
     };
 
     if (typeof prevResult !== 'undefined') {


### PR DESCRIPTION
… of errors

When  render functions receive an unknow type of Error it throws an non valid response for the
resolver (unit or pipeline)

fix #5502

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.