### PR TITLE
fix(amplify-nodejs-function-runtime-provider): invoke waits close eve…

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/invoke.test.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/invoke.test.ts
@@ -1,0 +1,216 @@
+import * as execa from 'execa';
+import { invoke } from '../../utils/invoke';
+import { InvokeOptions } from '../../utils/invokeOptions';
+
+jest.mock('execa');
+const execa_mock = execa as jest.Mocked<typeof execa>;
+
+class ExecaChildProcessMock {
+  public stdout = {
+    on: jest.fn(),
+  };
+  public on = jest.fn();
+  public catch = jest.fn();
+  public send = jest.fn();
+}
+const defaultOptions: InvokeOptions = {
+  event: 'some event',
+  handler: 'some handler',
+  packageFolder: '.',
+};
+
+const findEvent = (eventName: string, calls: any[]) => {
+  return calls.find(call => call[0] == eventName);
+};
+
+const callCb = (eventNamel: string, data: any, mocked: jest.Mock) => {
+  const dataCallback = findEvent(eventNamel, mocked.mock.calls)[1];
+  dataCallback(data);
+};
+
+const EXIT_ERROR = new Error('process finishs with 1');
+const exitWithError = (mocked: ExecaChildProcessMock) => {
+  mocked.catch.mock.calls[0][0](EXIT_ERROR);
+};
+
+describe('invoke', () => {
+  describe('close event happens before exit', () => {
+    it('should succeed', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      callCb('data', '\n', mockInstance.stdout.on);
+      callCb(
+        'data',
+        JSON.stringify({
+          result: { attribute: 1 },
+        }),
+        mockInstance.stdout.on,
+      );
+
+      //Closes happens before exit
+      callCb('close', undefined, mockInstance.on);
+      exitWithError(mockInstance);
+
+      await expect(promise).resolves.toEqual({ attribute: 1 });
+    });
+  });
+
+  describe('close event happens after exit', () => {
+    it('should succeed', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      callCb('data', '\n', mockInstance.stdout.on);
+      callCb(
+        'data',
+        JSON.stringify({
+          result: { attribute: 1 },
+        }),
+        mockInstance.stdout.on,
+      );
+
+      //Closes happens before exit
+      exitWithError(mockInstance);
+      callCb('close', undefined, mockInstance.on);
+
+      await expect(promise).resolves.toEqual({ attribute: 1 });
+    });
+  });
+
+  describe('close event happens up to 2 seconds after exit', () => {
+    it('should succeed', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      callCb('data', '\n', mockInstance.stdout.on);
+      callCb(
+        'data',
+        JSON.stringify({
+          result: { attribute: 1 },
+        }),
+        mockInstance.stdout.on,
+      );
+
+      //Closes happens before exit
+      exitWithError(mockInstance);
+      setTimeout(() => {
+        callCb('close', undefined, mockInstance.on);
+      }, 1800);
+
+      await expect(promise).resolves.toEqual({ attribute: 1 });
+    });
+
+    it('should reject with error body', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      callCb('data', '\n', mockInstance.stdout.on);
+      callCb(
+        'data',
+        JSON.stringify({
+          error: 'some error',
+        }),
+        mockInstance.stdout.on,
+      );
+
+      //Closes happens before exit
+      exitWithError(mockInstance);
+      setTimeout(() => {
+        callCb('close', undefined, mockInstance.on);
+      }, 500);
+
+      await expect(promise).rejects.toEqual('some error');
+    });
+  });
+
+  describe('close event happens after 2 seconds after exit', () => {
+    it('should reject', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      callCb('data', '\n', mockInstance.stdout.on);
+      callCb(
+        'data',
+        JSON.stringify({
+          result: { attribute: 1 },
+        }),
+        mockInstance.stdout.on,
+      );
+
+      //Closes happens before exit
+      exitWithError(mockInstance);
+      setTimeout(() => {
+        callCb('close', undefined, mockInstance.on);
+      }, 2800);
+
+      await expect(promise).rejects.not.toBeNull();
+    });
+  });
+
+  describe('body with error', () => {
+    it('should reject', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      callCb('data', '\n', mockInstance.stdout.on);
+      callCb(
+        'data',
+        JSON.stringify({
+          error: { message: 'some error' },
+        }),
+        mockInstance.stdout.on,
+      );
+
+      //Closes happens before exit
+      exitWithError(mockInstance);
+      callCb('close', undefined, mockInstance.on);
+
+      await expect(promise).rejects.toEqual({
+        message: 'some error',
+      });
+    });
+  });
+
+  describe('without data', () => {
+    it('should reject', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      //Closes happens before exit
+      exitWithError(mockInstance);
+      callCb('close', undefined, mockInstance.on);
+
+      await expect(promise).rejects.toEqual(EXIT_ERROR.message);
+    });
+  });
+
+  describe('body with invalid JSON', () => {
+    it('should reject', async () => {
+      const mockInstance = new ExecaChildProcessMock();
+      execa_mock.node.mockImplementation(file => mockInstance as any);
+      const promise = invoke(defaultOptions);
+      const invalidJson = 'Invalid Json {[';
+
+      callCb('data', '\n', mockInstance.stdout.on);
+      callCb('data', invalidJson, mockInstance.stdout.on);
+
+      //Closes happens before exit
+      exitWithError(mockInstance);
+      callCb('close', undefined, mockInstance.on);
+
+      await expect(promise).resolves.toEqual(invalidJson);
+    });
+  });
+
+  describe('unexpected throw', () => {
+    it('should reject', async () => {
+      const error = new Error('unexpected error');
+      execa_mock.node.mockImplementation(file => {
+        throw error;
+      });
+      const promise = invoke(defaultOptions);
+      await expect(promise).rejects.toEqual(error);
+    });
+  });
+});

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/invoke.ts
@@ -13,7 +13,8 @@ export function invoke(options: InvokeOptions): Promise<any> {
       lambdaFn.stdout.on('data', msg => {
         data += msg;
       });
-      lambdaFn.on('close', () => {
+      let inClosePromise: Promise<void> | null;
+      const onClose = async () => {
         const lines = data.split('\n');
         if (lines.length > 1) {
           const logs = lines.slice(0, -1).join('\n');
@@ -27,11 +28,28 @@ export function invoke(options: InvokeOptions): Promise<any> {
           }
           resolve(result.result);
         } catch {
-          resolve(lastLine)
+          resolve(lastLine);
         }
+      };
+      lambdaFn.on('close', () => {
+        inClosePromise = onClose();
       });
-      lambdaFn.catch((err) => {
-        reject(err.message);
+      lambdaFn.catch(err => {
+        const rejectWithClose = () => {
+          if (inClosePromise) {
+            inClosePromise.finally(() => {
+              reject(err.message);
+            });
+          } else {
+            reject(err.message);
+          }
+        };
+
+        if (data.length > 0) {
+          setTimeout(() => rejectWithClose(), 2000);
+        } else {
+          rejectWithClose();
+        }
       });
       lambdaFn.send(JSON.stringify(options));
     } catch (e) {


### PR DESCRIPTION
…nt before rejects

execa module waits untill all output is drained, but it can sends the 'close' event after the the
promise is rejected. Or the promise is rejected after close event but before before functions
finishs. The change will upto 2 seconds to event close is been sent and waits until the close call
back is completed

fix #4439

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.